### PR TITLE
Lead with 0BSD

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Software has 0BSD license
+0BSD license for software
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.


### PR DESCRIPTION
Reword #7 because Github's license detector didn't recognize that way as `0BSD`