### PR TITLE
Like zero

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-0BSD software license
+0BSD License
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted.


### PR DESCRIPTION
### Re: #7 #8 #9

Keep license heading same as in [`s9a/zero`](https://github.com/s9a/zero) at least for now. My current understanding is that because [`0BSD`](https://choosealicense.com/licenses/0bsd/) is a software license it applies only to software and not to cultural works. I plan to confirm that via [law.stackexchange.com](https://law.stackexchange.com) and will update if needed. 